### PR TITLE
chore: add vscode settings to auto-select python kernels based on module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -208,3 +208,7 @@ __marimo__/
 
 
 .DS_Store
+
+# Track specific VS Code settings for student environments to auto-select kernels
+!**/.vscode/
+!**/.vscode/settings.json

--- a/module-10-implementing-neural-networks-using-pytorch/demo-comparing-optimizers/.vscode/settings.json
+++ b/module-10-implementing-neural-networks-using-pytorch/demo-comparing-optimizers/.vscode/settings.json
@@ -1,0 +1,1 @@
+{"python.defaultInterpreterPath": "/voc/data/venv1/bin/python"}

--- a/module-10-implementing-neural-networks-using-pytorch/demo-intro-pytorch/.vscode/settings.json
+++ b/module-10-implementing-neural-networks-using-pytorch/demo-intro-pytorch/.vscode/settings.json
@@ -1,0 +1,1 @@
+{"python.defaultInterpreterPath": "/voc/data/venv1/bin/python"}

--- a/module-10-implementing-neural-networks-using-pytorch/exercises/solution/.vscode/settings.json
+++ b/module-10-implementing-neural-networks-using-pytorch/exercises/solution/.vscode/settings.json
@@ -1,0 +1,1 @@
+{"python.defaultInterpreterPath": "/voc/data/venv1/bin/python"}

--- a/module-10-implementing-neural-networks-using-pytorch/exercises/starter/.vscode/settings.json
+++ b/module-10-implementing-neural-networks-using-pytorch/exercises/starter/.vscode/settings.json
@@ -1,0 +1,1 @@
+{"python.defaultInterpreterPath": "/voc/data/venv1/bin/python"}

--- a/module-12-generating-text-using-llms/exercises/solution/.vscode/settings.json
+++ b/module-12-generating-text-using-llms/exercises/solution/.vscode/settings.json
@@ -1,0 +1,1 @@
+{"python.defaultInterpreterPath": "/voc/data/venv1/bin/python"}

--- a/module-12-generating-text-using-llms/exercises/starter/.vscode/settings.json
+++ b/module-12-generating-text-using-llms/exercises/starter/.vscode/settings.json
@@ -1,0 +1,1 @@
+{"python.defaultInterpreterPath": "/voc/data/venv1/bin/python"}

--- a/module-12-generating-text-using-llms/generating-text-demo/.vscode/settings.json
+++ b/module-12-generating-text-using-llms/generating-text-demo/.vscode/settings.json
@@ -1,0 +1,1 @@
+{"python.defaultInterpreterPath": "/voc/data/venv1/bin/python"}

--- a/module-12-generating-text-using-llms/huggingface-demo/.vscode/settings.json
+++ b/module-12-generating-text-using-llms/huggingface-demo/.vscode/settings.json
@@ -1,0 +1,1 @@
+{"python.defaultInterpreterPath": "/voc/data/venv1/bin/python"}

--- a/module-16-applying-peft-on-foundation-models/demo/.vscode/settings.json
+++ b/module-16-applying-peft-on-foundation-models/demo/.vscode/settings.json
@@ -1,0 +1,1 @@
+{"python.defaultInterpreterPath": "/voc/data/venv2/bin/python"}

--- a/module-16-applying-peft-on-foundation-models/exercises/solution/.vscode/settings.json
+++ b/module-16-applying-peft-on-foundation-models/exercises/solution/.vscode/settings.json
@@ -1,0 +1,1 @@
+{"python.defaultInterpreterPath": "/voc/data/venv2/bin/python"}

--- a/module-16-applying-peft-on-foundation-models/exercises/starter/.vscode/settings.json
+++ b/module-16-applying-peft-on-foundation-models/exercises/starter/.vscode/settings.json
@@ -1,0 +1,1 @@
+{"python.defaultInterpreterPath": "/voc/data/venv2/bin/python"}

--- a/module-18-reinforcement-fine-tuning-on-foundation-models/demo/.vscode/settings.json
+++ b/module-18-reinforcement-fine-tuning-on-foundation-models/demo/.vscode/settings.json
@@ -1,0 +1,1 @@
+{"python.defaultInterpreterPath": "/voc/data/venv2/bin/python"}

--- a/module-18-reinforcement-fine-tuning-on-foundation-models/exercises/solution/.vscode/settings.json
+++ b/module-18-reinforcement-fine-tuning-on-foundation-models/exercises/solution/.vscode/settings.json
@@ -1,0 +1,1 @@
+{"python.defaultInterpreterPath": "/voc/data/venv2/bin/python"}

--- a/module-18-reinforcement-fine-tuning-on-foundation-models/exercises/starter/.vscode/settings.json
+++ b/module-18-reinforcement-fine-tuning-on-foundation-models/exercises/starter/.vscode/settings.json
@@ -1,0 +1,1 @@
+{"python.defaultInterpreterPath": "/voc/data/venv2/bin/python"}

--- a/module-8-implementing-evaluations-for-generative-ai-models/demo/.vscode/settings.json
+++ b/module-8-implementing-evaluations-for-generative-ai-models/demo/.vscode/settings.json
@@ -1,0 +1,1 @@
+{"python.defaultInterpreterPath": "/voc/data/venv1/bin/python"}

--- a/module-8-implementing-evaluations-for-generative-ai-models/exercises/solution/.vscode/settings.json
+++ b/module-8-implementing-evaluations-for-generative-ai-models/exercises/solution/.vscode/settings.json
@@ -1,0 +1,1 @@
+{"python.defaultInterpreterPath": "/voc/data/venv1/bin/python"}

--- a/module-8-implementing-evaluations-for-generative-ai-models/exercises/starter/.vscode/settings.json
+++ b/module-8-implementing-evaluations-for-generative-ai-models/exercises/starter/.vscode/settings.json
@@ -1,0 +1,1 @@
+{"python.defaultInterpreterPath": "/voc/data/venv1/bin/python"}

--- a/project/starter/.vscode/settings.json
+++ b/project/starter/.vscode/settings.json
@@ -1,0 +1,1 @@
+{"python.defaultInterpreterPath": "/voc/data/venv2/bin/python"}


### PR DESCRIPTION
## Summary
- Ship `.vscode/settings.json` in 18 directories so the correct Python interpreter is auto-selected when students open notebooks in VS Code.
- `venv1` (modules 8, 10, 12 — demos, exercise starters, exercise solutions): 11 files.
- `venv2` (modules 16, 18 — demos, exercise starters, exercise solutions — plus the project starter): 7 files.
- Update `.gitignore` with negation rules (`!**/.vscode/`, `!**/.vscode/settings.json`) so these files ship even when a contributor's global gitignore excludes `.vscode/`.

### Mapping
| Path glob | Interpreter |
|---|---|
| `module-8/{demo,exercises/starter,exercises/solution}` | `/voc/data/venv1/bin/python` |
| `module-10/{demo-comparing-optimizers,demo-intro-pytorch,exercises/starter,exercises/solution}` | `/voc/data/venv1/bin/python` |
| `module-12/{generating-text-demo,huggingface-demo,exercises/starter,exercises/solution}` | `/voc/data/venv1/bin/python` |
| `module-16/{demo,exercises/starter,exercises/solution}` | `/voc/data/venv2/bin/python` |
| `module-18/{demo,exercises/starter,exercises/solution}` | `/voc/data/venv2/bin/python` |
| `project/starter` | `/voc/data/venv2/bin/python` |

Modules 10 and 12 each have two demo directories — both received the venv1 settings under the assumption that "demos" (plural) covers them all.

## Test plan
- [ ] Clone the branch into a Voc workspace and confirm `/voc/data/venv1/bin/python` is auto-selected for a module 8/10/12 notebook.
- [ ] Confirm `/voc/data/venv2/bin/python` is auto-selected for a module 16/18 notebook and for `project/starter`.
- [ ] Verify the `.vscode/` directories appear in the cloned tree (not silently ignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)